### PR TITLE
configure aide correctly

### DIFF
--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -528,6 +528,19 @@
       - patch
       - rule_1.3.1
 
+- name: "Configure aide"
+  lineinfile:
+    state: present
+      dest: /etc/aide.conf
+      insertafter: EOF
+      line: "{{item}}"
+  become: true
+  with_items:
+    - '!/var/lib/lxcfs'
+    - '!/run'
+    - '!/tmp'
+    - '!/var/log'
+    - '!/var/awslogs'
 
 - name: "SCORED | 1.3.1 | PATCH | Init AIDE"
   shell: aideinit && mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db


### PR DESCRIPTION
quiet aide down by excluding the tmp, log, and lxcfs directories which are known volatile. 